### PR TITLE
add  ROS binary for `tf_transformations` since its officially published now

### DIFF
--- a/uuv_plume_simulator/package.xml
+++ b/uuv_plume_simulator/package.xml
@@ -17,6 +17,7 @@
   <!-- <buildtool_depend>ament_python</buildtool_depend> -->
 
   <depend>rclpy</depend>
+  <depend>tf_transformations</depend>
 
 <!--  <test_depend>ament_copyright</test_depend>-->
 <!--  <test_depend>ament_flake8</test_depend>-->


### PR DESCRIPTION
it is available for  ROS binary now https://github.com/DLu/tf_transformations?tab=readme-ov-file#installation
removes the need for another submodule.